### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-06-01"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2023-06-01"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
"nightly" is too unspecific. It matches older incompatible compiler versions. We need to precisely define the compiler version.